### PR TITLE
WAYLAND: Add Wayland support

### DIFF
--- a/io.github.snesrev.Zelda3.yml
+++ b/io.github.snesrev.Zelda3.yml
@@ -7,6 +7,7 @@ command: zelda3.py
 finish-args:
  - --device=all
  - --share=ipc
+ - --socket=wayland
  - --socket=x11
  - --socket=pulseaudio
 modules:

--- a/io.github.snesrev.Zelda3.yml
+++ b/io.github.snesrev.Zelda3.yml
@@ -8,7 +8,7 @@ finish-args:
  - --device=all
  - --share=ipc
  - --socket=wayland
- - --socket=x11
+ - --socket=fallback-x11
  - --socket=pulseaudio
 modules:
  - name: python3-pillow

--- a/zelda3.py
+++ b/zelda3.py
@@ -89,4 +89,7 @@ else:
     if os.system('for i in {1..20}; do echo $((i * 5)); sleep 0.1; done | zenity --progress --title="Starting..." --text="Wait for start" --cancel-label "Open Config file" --ok-label "" --auto-close --auto-kill') != 0:
         os.system('xdg-open zelda3.ini')
         quit()
+
+if os.environ.get('XDG_SESSION_TYPE') == "wayland":
+    os.environ['SDL_VIDEODRIVER'] = "wayland"
 os.system('zelda3')


### PR DESCRIPTION
Zelda3 uses SDL, which has native Wayland support.